### PR TITLE
Add Docker setup and convert backend to FastAPI

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Example environment variables for backend
+# Add your configuration here

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY packages/backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY packages/backend ./
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,15 @@
+FROM node:18
+
+WORKDIR /app
+
+# Copy frontend source
+COPY packages/frontend ./packages/frontend
+
+WORKDIR /app/packages/frontend
+
+# Install dependencies and build
+RUN corepack enable && pnpm install && pnpm build
+
+EXPOSE 3000
+
+CMD ["pnpm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "3000:3000"
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -1,13 +1,28 @@
-"""Entry point for the backend service."""
+"""FastAPI backend service entry point."""
 
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from orchestrator import Orchestrator
 
+app = FastAPI()
 
-def main() -> None:
-    """Run the orchestrator."""
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "Backend running"}
+
+
+@app.post("/run")
+def run_orchestration() -> dict[str, str]:
+    """Trigger the orchestrator workflow."""
     orchestrator = Orchestrator()
     orchestrator.run()
-
-
-if __name__ == "__main__":
-    main()
+    return {"detail": "Orchestration started"}

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -1,2 +1,4 @@
 boto3>=1.28
 requests>=2.31
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- add docker-compose config for frontend and backend
- add Dockerfiles for both services
- include a sample `.env`
- convert backend CLI to FastAPI app
- update backend requirements

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879bd86c198832fb8654c3c40d3848a