### PR TITLE
Add basic technology dataset and embedding loader

### DIFF
--- a/packages/backend/applications.json
+++ b/packages/backend/applications.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "app1",
+    "name": "Customer Portal",
+    "description": "Public facing website for customers to view and manage accounts.",
+    "technologies": ["React", "Node.js", "AWS"]
+  },
+  {
+    "id": "app2",
+    "name": "Claims Processing",
+    "description": "Internal service for handling insurance claims.",
+    "technologies": ["Java", "Spring Boot", "Oracle DB"]
+  }
+]

--- a/packages/backend/load_embeddings.py
+++ b/packages/backend/load_embeddings.py
@@ -1,0 +1,53 @@
+"""Generate and store vector embeddings for technology data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+import faiss
+from sentence_transformers import SentenceTransformer
+
+DATA_FILES = [
+    Path(__file__).with_name("technology_capabilities.json"),
+    Path(__file__).with_name("applications.json"),
+]
+
+
+def load_entries() -> List[Dict[str, str]]:
+    """Load technology catalog entries from JSON files."""
+    entries: List[Dict[str, str]] = []
+    for path in DATA_FILES:
+        if path.exists():
+            with path.open("r", encoding="utf-8") as fh:
+                records = json.load(fh)
+                if isinstance(records, list):
+                    entries.extend(records)
+    return entries
+
+
+def build_index(texts: List[str], model_name: str = "all-MiniLM-L6-v2") -> faiss.Index:
+    """Create a FAISS index from the provided texts."""
+    model = SentenceTransformer(model_name)
+    embeddings = model.encode(texts, convert_to_numpy=True)
+    embeddings = embeddings.astype("float32")
+    index = faiss.IndexFlatL2(embeddings.shape[1])
+    index.add(embeddings)
+    return index
+
+
+def main() -> None:
+    entries = load_entries()
+    texts = [e.get("description", "") for e in entries]
+    index = build_index(texts)
+
+    out_dir = Path(__file__).with_name("vector_store")
+    out_dir.mkdir(exist_ok=True)
+    faiss.write_index(index, str(out_dir / "index.faiss"))
+    with (out_dir / "metadata.json").open("w", encoding="utf-8") as fh:
+        json.dump(entries, fh, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -2,3 +2,5 @@ boto3>=1.28
 requests>=2.31
 fastapi
 uvicorn[standard]
+sentence-transformers>=2.5
+faiss-cpu>=1.7

--- a/packages/backend/technology_capabilities.json
+++ b/packages/backend/technology_capabilities.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "cap1",
+    "name": "Kubernetes",
+    "category": "container orchestration",
+    "description": "Manages containers at scale with automatic deployment and scaling."
+  },
+  {
+    "id": "cap2",
+    "name": "Docker",
+    "category": "containerization",
+    "description": "Packages applications and dependencies into portable containers."
+  },
+  {
+    "id": "cap3",
+    "name": "Amazon S3",
+    "category": "object storage",
+    "description": "Highly durable storage for static assets and backups."
+  }
+]


### PR DESCRIPTION
## Summary
- add technology catalog JSON files for capabilities and applications
- implement `load_embeddings.py` to vectorize the catalog data using FAISS
- extend backend requirements with sentence-transformers and faiss-cpu

## Testing
- `pip install -r requirements.txt` *(fails: Could not install dependencies)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879c443a1f8832f9cbfb08a9faea39f