### PR TITLE
Add application ranking

### DIFF
--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -4,3 +4,4 @@ fastapi
 uvicorn[standard]
 sentence-transformers>=2.5
 faiss-cpu>=1.7
+langchain>=0.1.0


### PR DESCRIPTION
## Summary
- expand orchestrator to load applications and embed them
- provide a Bedrock LLM wrapper for LangChain
- rank applications with a LangChain `LLMChain`
- add `langchain` to backend requirements

## Testing
- `python -m py_compile packages/backend/orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_6879c7c7e03c832f8d9eeaa28c104309