### PR TITLE
Implement orchestrator response chain

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -21,8 +21,9 @@ def read_root() -> dict[str, str]:
 
 
 @app.post("/run")
-def run_orchestration() -> dict[str, str]:
+def run_orchestration(request: dict[str, str]) -> dict[str, str]:
     """Trigger the orchestrator workflow."""
+    query = request.get("query", "")
     orchestrator = Orchestrator()
-    orchestrator.run()
-    return {"detail": "Orchestration started"}
+    answer = orchestrator.run(query)
+    return {"answer": answer}


### PR DESCRIPTION
## Summary
- add synthesizer system prompt
- generate conversational response from ranked apps
- chain capability and app recommendation in `run`
- accept a query in backend `/run` endpoint

## Testing
- `python -m py_compile packages/backend/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c889ae34832f8c5ff77a7eb11d7c