### PR TITLE
Add /ask route to backend

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -20,10 +20,10 @@ def read_root() -> dict[str, str]:
     return {"status": "Backend running"}
 
 
-@app.post("/run")
-def run_orchestration(request: dict[str, str]) -> dict[str, str]:
-    """Trigger the orchestrator workflow."""
-    query = request.get("query", "")
+@app.post("/ask")
+def ask_question(request: dict[str, str]) -> dict[str, str]:
+    """Run the orchestrator with the provided question."""
+    question = request.get("question", "")
     orchestrator = Orchestrator()
-    answer = orchestrator.run(query)
+    answer = orchestrator.run(question)
     return {"answer": answer}


### PR DESCRIPTION
## Summary
- implement POST `/ask` endpoint for the backend
- remove old `/run` route

## Testing
- `python -m py_compile packages/backend/main.py packages/backend/orchestrator.py packages/backend/abacus_client.py packages/backend/bedrock_adapter.py packages/backend/load_embeddings.py`
- `python packages/backend/main.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6879ca1c49c8832f961f61435c31b724