### PR TITLE
Add env example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment variables for the backend
+
+# AWS Bedrock configuration
+BEDROCK_API_BASE=https://bedrock.example.com
+BEDROCK_API_KEY=your-bedrock-api-key
+BEDROCK_MODEL_ID=model-id
+BEDROCK_TIMEOUT=15
+BEDROCK_MAX_TOKENS=2048
+BEDROCK_TEMPERATURE=0.7
+
+# ABACUS service configuration
+ABACUS_BASE_URL=https://abacus.example.com
+ABACUS_CLIENT_SECRET=your-abacus-secret
+ABACUS_TIMEOUT=15

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Configuration
+
+Copy `.env.example` to `.env` and fill in your credentials. At a minimum the
+backend requires AWS Bedrock and ABACUS settings:
+
+- `BEDROCK_API_BASE` and `BEDROCK_API_KEY`
+- `BEDROCK_MODEL_ID`
+- `ABACUS_BASE_URL` and `ABACUS_CLIENT_SECRET`
+
+The service exposes a POST `/ask` endpoint used by the frontend to retrieve
+answers.
+
 ## How It Works
 
 1. Create and modify your project using [v0.dev](https://v0.dev)

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -20,9 +20,19 @@ placeholders that will be expanded as the service evolves.
 
 3. Install Python dependencies:
 
-   ```bash
-   pip install -r requirements.txt
-   ```
+```bash
+pip install -r requirements.txt
+```
+
+## Environment variables
+
+Copy `../../.env.example` to `.env` in the repository root and populate the
+required values:
+
+- `BEDROCK_API_BASE`, `BEDROCK_API_KEY`, and `BEDROCK_MODEL_ID`
+- `ABACUS_BASE_URL` and `ABACUS_CLIENT_SECRET`
+
+These settings allow the service to call AWS Bedrock and the ABACUS API.
 
 ## Running
 
@@ -31,6 +41,9 @@ Activate your environment if you haven't already and run:
 ```bash
 python main.py
 ```
+
+Once running, the API exposes a `/ask` endpoint that accepts a JSON payload with
+a `question` field and returns the generated answer.
 
 The current scripts raise `NotImplementedError` until the backend logic
 is implemented.


### PR DESCRIPTION
## Summary
- include a `.env.example` with backend config variables
- document environment variables in the main README
- expand backend README with env info and `/ask` endpoint details

## Testing
- `python -m py_compile packages/backend/*.py`
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ce4ff000832fad119714b7438abc