### PR TITLE
Use env var for API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ BEDROCK_TEMPERATURE=0.7
 ABACUS_BASE_URL=https://abacus.example.com
 ABACUS_CLIENT_SECRET=your-abacus-secret
 ABACUS_TIMEOUT=15
+
+# Frontend configuration
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.1] - 2025-07-11
 ### Added
-- `http://localhost:8000/ask` endpoint for streaming AI responses.
+- `/ask` endpoint for streaming AI responses (URL configurable via
+  `NEXT_PUBLIC_API_URL`).
 - FAQ page for common questions about using ABACUS.
 - Prompt suggestions loaded from `public/prompts.json`.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Continue building your app on:
 
 ## Features
 
-- Interactive chat powered by OpenAI via `http://localhost:8000/ask`
+- Interactive chat powered by OpenAI via the `/ask` endpoint
+  (backend URL configurable with `NEXT_PUBLIC_API_URL`)
 - Suggested prompts loaded from `public/prompts.json`
 - FAQ section available at `/faq`
 
@@ -55,7 +56,8 @@ backend requires AWS Bedrock and ABACUS settings:
 - `ABACUS_BASE_URL` and `ABACUS_CLIENT_SECRET`
 
 The service exposes a POST `/ask` endpoint used by the frontend to retrieve
-answers.
+answers. Point the frontend to the backend by setting `NEXT_PUBLIC_API_URL`
+in `packages/frontend/.env` (see `packages/frontend/.env.example`).
 
 ## How It Works
 

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/packages/frontend/app/page.tsx
+++ b/packages/frontend/app/page.tsx
@@ -91,8 +91,10 @@ export default function Chat() {
 
     setIsLoading(true)
     setIsProcessing(true)
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+
     try {
-      const res = await fetch("http://localhost:8000/ask", {
+      const res = await fetch(`${apiUrl}/ask`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ question }),


### PR DESCRIPTION
## Summary
- make frontend fetch URL configurable via `NEXT_PUBLIC_API_URL`
- provide example env files
- document new env var in README and changelog

## Testing
- `pnpm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6879d1f317f4832f8952861c0dd6f582