### PR TITLE
Persist and load FAISS index

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -24,6 +24,12 @@ placeholders that will be expanded as the service evolves.
 pip install -r requirements.txt
 ```
 
+4. **Generate embeddings** (required on first run):
+
+```bash
+python load_embeddings.py
+```
+
 ## Environment variables
 
 Copy `../../.env.example` to `.env` in the repository root and populate the
@@ -41,6 +47,10 @@ Activate your environment if you haven't already and run:
 ```bash
 python main.py
 ```
+
+Make sure `load_embeddings.py` has been executed at least once so that
+the FAISS index exists before starting the service. If the index is
+missing, it will be built automatically on startup.
 
 Once running, the API exposes a `/ask` endpoint that accepts a JSON payload with
 a `question` field and returns the generated answer.


### PR DESCRIPTION
## Summary
- load prebuilt FAISS index and metadata in orchestrator
- build and persist index if missing
- document running `load_embeddings.py` before starting backend

## Testing
- `python -m py_compile packages/backend/orchestrator.py packages/backend/load_embeddings.py`

------
https://chatgpt.com/codex/tasks/task_e_6879d5638750832fb438885eca70cce1