### PR TITLE
Update query history to store message ids

### DIFF
--- a/packages/frontend/app/page.tsx
+++ b/packages/frontend/app/page.tsx
@@ -117,7 +117,9 @@ export default function Chat() {
   }
 
   /* -------- misc ---------- */
-  const queryHistory = messages.filter((m) => m.role === "user").map((m) => m.content)
+  const queryHistory = messages
+    .filter((m) => m.role === "user")
+    .map((m) => ({ id: m.id, content: m.content }))
   const chatContainerRef = useRef<HTMLDivElement>(null)
 
   /* -------------------- effects -------------------- */

--- a/packages/frontend/components/chat/Sidebar.tsx
+++ b/packages/frontend/components/chat/Sidebar.tsx
@@ -7,7 +7,7 @@ interface Props {
   isMobile: boolean
   isDrawerOpen: boolean
   setIsDrawerOpen: (open: boolean) => void
-  queryHistory: string[]
+  queryHistory: { id: string; content: string }[]
   setInput: (value: string) => void
   setMessages: React.Dispatch<any>
   setIsAboutDialogOpen: (open: boolean) => void

--- a/packages/frontend/components/chat/SidebarContent.tsx
+++ b/packages/frontend/components/chat/SidebarContent.tsx
@@ -16,7 +16,7 @@ import { Add, PersonOutline, History, InfoOutlined } from "@mui/icons-material"
 import { fadeIn } from "./animations"
 
 interface Props {
-  queryHistory: string[]
+  queryHistory: { id: string; content: string }[]
   setInput: (value: string) => void
   setMessages: React.Dispatch<any>
   isMobile: boolean
@@ -109,17 +109,17 @@ export default function SidebarContent({
         {queryHistory.length ? (
           <List dense>
             {[...queryHistory].reverse().map((q, i) => (
-              <Box key={i} sx={{ animation: `${fadeIn} 0.5s ease ${i * 0.05}s both` }}>
+              <Box key={q.id} sx={{ animation: `${fadeIn} 0.5s ease ${i * 0.05}s both` }}>
                 <ListItem disablePadding>
                   <ListItemButton
                     onClick={() => {
-                      setInput(q)
+                      setInput(q.content)
                       if (isMobile) setIsDrawerOpen(false)
                     }}
                     sx={{ borderRadius: 1 }}
                   >
                     <ListItemText
-                      primary={q}
+                      primary={q.content}
                       primaryTypographyProps={{
                         noWrap: true,
                         sx: { color: "#E0E0E0" }


### PR DESCRIPTION
## Summary
- store message `id` and `content` in `queryHistory`
- adjust sidebar prop types for updated history object
- render sidebar history using message ids

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm install` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6879d8ff9868832f97053460cba7e533