### PR TITLE
Add error boundary around Chat

### DIFF
--- a/packages/frontend/app/page.tsx
+++ b/packages/frontend/app/page.tsx
@@ -24,6 +24,7 @@ import Sidebar from "@/components/chat/Sidebar"
 import ChatMessages from "@/components/chat/ChatMessages"
 import WelcomeScreen from "@/components/chat/WelcomeScreen"
 import ChatInputForm from "@/components/chat/ChatInputForm"
+import ErrorBoundary from "@/components/ErrorBoundary"
 
 /* ------------- Slide transition that always keeps node mounted -------- */
 
@@ -57,7 +58,7 @@ const logger = {
 
 /* ============================= PAGE =================================== */
 
-export default function Chat() {
+export function Chat() {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down("md"))
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -299,5 +300,13 @@ export default function Chat() {
         </DialogActions>
       </Dialog>
     </Box>
+  )
+}
+
+export default function Page() {
+  return (
+    <ErrorBoundary>
+      <Chat />
+    </ErrorBoundary>
   )
 }

--- a/packages/frontend/components/ErrorBoundary.tsx
+++ b/packages/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { Box, Typography } from "@mui/material"
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box sx={{ p: 4, textAlign: "center" }}>
+          <Typography variant="h6" color="error" gutterBottom>
+            Something went wrong.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {this.state.error?.message}
+          </Typography>
+        </Box>
+      )
+    }
+
+    return this.props.children
+  }
+}


### PR DESCRIPTION
## Summary
- create `ErrorBoundary` component for catching render errors
- wrap chat page with the new error boundary

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879da1b7288832fb2b25f4f32fa56ef