### PR TITLE
Add loading spinner

### DIFF
--- a/packages/frontend/app/loading.tsx
+++ b/packages/frontend/app/loading.tsx
@@ -1,3 +1,17 @@
+"use client"
+import { Box, CircularProgress } from "@mui/material"
+
 export default function Loading() {
-  return null
+  return (
+    <Box
+      sx={{
+        height: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <CircularProgress color="primary" />
+    </Box>
+  )
 }


### PR DESCRIPTION
## Summary
- improve UX by showing a spinner during route transitions

## Testing
- `pnpm lint` *(fails: next not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879dca03d90832f8d6b8deacb50d4f8