### PR TITLE
Remove deprecated isProcessing state

### DIFF
--- a/packages/frontend/app/page.tsx
+++ b/packages/frontend/app/page.tsx
@@ -62,7 +62,6 @@ export function Chat() {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down("md"))
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const [isProcessing, setIsProcessing] = useState(false)
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
 
   /* -------- authentication / user menu ---------- */
@@ -91,7 +90,6 @@ export function Chat() {
     setInput("")
 
     setIsLoading(true)
-    setIsProcessing(true)
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
 
     try {
@@ -112,7 +110,6 @@ export function Chat() {
       }
       setMessages((prev) => [...prev, errorMessage])
     } finally {
-      setIsProcessing(false)
       setIsLoading(false)
     }
   }
@@ -148,10 +145,6 @@ export function Chat() {
   useEffect(() => {
     scrollToBottom()
   }, [messages, scrollToBottom])
-
-  useEffect(() => {
-    setIsProcessing(isLoading)
-  }, [isLoading])
 
   /* ------------------- handlers ------------------- */
 
@@ -255,7 +248,6 @@ export function Chat() {
           input={input}
           onChange={handleInputChange}
           onSubmit={handleSubmit}
-          isProcessing={isProcessing}
           isLoading={isLoading}
         />
 

--- a/packages/frontend/components/chat/ChatInputForm.tsx
+++ b/packages/frontend/components/chat/ChatInputForm.tsx
@@ -7,11 +7,10 @@ interface Props {
   input: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  isProcessing: boolean
   isLoading: boolean
 }
 
-export default function ChatInputForm({ input, onChange, onSubmit, isProcessing, isLoading }: Props) {
+export default function ChatInputForm({ input, onChange, onSubmit, isLoading }: Props) {
   return (
     <Box sx={{ p: { xs: 1, md: 2 }, bgcolor: "transparent" }}>
       <Paper
@@ -34,7 +33,7 @@ export default function ChatInputForm({ input, onChange, onSubmit, isProcessing,
           onChange={onChange}
           multiline
           maxRows={5}
-          disabled={isProcessing}
+          disabled={isLoading}
           InputProps={{ disableUnderline: true, sx: { p: "10px 20px" } }}
         />
         <Button
@@ -42,9 +41,9 @@ export default function ChatInputForm({ input, onChange, onSubmit, isProcessing,
           variant="contained"
           disabled={isLoading || !input.trim()}
           sx={{ borderRadius: "20px", mr: 1 }}
-          startIcon={isProcessing ? <CircularProgress size={16} color="inherit" /> : <AutoAwesome />}
+          startIcon={isLoading ? <CircularProgress size={16} color="inherit" /> : <AutoAwesome />}
         >
-          {isProcessing ? "..." : "Ask"}
+          {isLoading ? "..." : "Ask"}
         </Button>
       </Paper>
     </Box>


### PR DESCRIPTION
## Summary
- clean up `isProcessing` logic from chat page
- rely on `isLoading` in `ChatInputForm`

## Testing
- `pnpm lint` *(fails: next not found due to missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_6879e0c5a3b0832f94a7d6e55201ef12