### PR TITLE
Make SSL verification configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,8 @@ ABACUS_BASE_URL=https://abacus.example.com
 ABACUS_CLIENT_SECRET=your-abacus-secret
 ABACUS_TIMEOUT=15
 
+# SSL verification for external services
+VERIFY_SSL=true
+
 # Frontend configuration
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ backend requires AWS Bedrock and ABACUS settings:
 - `BEDROCK_API_BASE` and `BEDROCK_API_KEY`
 - `BEDROCK_MODEL_ID`
 - `ABACUS_BASE_URL` and `ABACUS_CLIENT_SECRET`
+- `VERIFY_SSL` (set to `false` to allow self-signed certificates)
 
 The service exposes a POST `/ask` endpoint used by the frontend to retrieve
 answers. Point the frontend to the backend by setting `NEXT_PUBLIC_API_URL`

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -37,6 +37,7 @@ required values:
 
 - `BEDROCK_API_BASE`, `BEDROCK_API_KEY`, and `BEDROCK_MODEL_ID`
 - `ABACUS_BASE_URL` and `ABACUS_CLIENT_SECRET`
+- `VERIFY_SSL` (set to `false` to allow self-signed certificates)
 
 These settings allow the service to call AWS Bedrock and the ABACUS API.
 

--- a/packages/backend/abacus_client.py
+++ b/packages/backend/abacus_client.py
@@ -6,10 +6,6 @@ import os
 from typing import Any, Dict
 
 import requests
-import urllib3
-
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class AbacusClient:
@@ -19,6 +15,12 @@ class AbacusClient:
         self.base_url = os.getenv("ABACUS_BASE_URL", "").rstrip("/")
         self.client_secret = os.getenv("ABACUS_CLIENT_SECRET", "")
         self.timeout = int(os.getenv("ABACUS_TIMEOUT", "15"))
+        # Honor VERIFY_SSL=false to allow self-signed certificates during development
+        self.verify_ssl = os.getenv("VERIFY_SSL", "true").lower() not in {
+            "0",
+            "false",
+            "no",
+        }
 
         self._headers = {
             "Authorization": f"Bearer {self.client_secret}",
@@ -39,7 +41,7 @@ class AbacusClient:
                 headers=self._headers,
                 json=payload,
                 timeout=self.timeout,
-                verify=False,  # ABACUS may use self-signed certs
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
             return response.json()

--- a/packages/backend/bedrock_adapter.py
+++ b/packages/backend/bedrock_adapter.py
@@ -6,10 +6,6 @@ import os
 from typing import Any, Dict, List
 
 import requests
-import urllib3
-
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class BedrockAdapter:
@@ -22,6 +18,12 @@ class BedrockAdapter:
         self.timeout = int(os.getenv("BEDROCK_TIMEOUT", "15"))
         self.max_tokens = int(os.getenv("BEDROCK_MAX_TOKENS", "2048"))
         self.temperature = float(os.getenv("BEDROCK_TEMPERATURE", "0.7"))
+        # Honor VERIFY_SSL=false to allow self-signed certificates during development
+        self.verify_ssl = os.getenv("VERIFY_SSL", "true").lower() not in {
+            "0",
+            "false",
+            "no",
+        }
 
         self._headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -42,7 +44,7 @@ class BedrockAdapter:
                 headers=self._headers,
                 json=payload,
                 timeout=self.timeout,
-                verify=False,  # custom endpoints may use self-signed certs
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
             return response.json()


### PR DESCRIPTION
## Summary
- make certificate verification toggled by VERIFY_SSL environment variable
- remove urllib3 warning suppression
- document VERIFY_SSL in README and backend docs
- mention VERIFY_SSL in env example

## Testing
- `python -m py_compile packages/backend/abacus_client.py packages/backend/bedrock_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_6879e3cd2db0832fac9d9cd8fc68b285