### PR TITLE
Pin backend dependencies

### DIFF
--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -1,7 +1,7 @@
-boto3>=1.28
-requests>=2.31
-fastapi
-uvicorn[standard]
-sentence-transformers>=2.5
-faiss-cpu>=1.7
-langchain>=0.1.0
+boto3==1.28.0
+requests==2.31.0
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+sentence-transformers==2.5.1
+faiss-cpu==1.7.4
+langchain==0.1.0


### PR DESCRIPTION
## Summary
- pin boto3, requests, and other backend dependencies to specific versions

## Testing
- `pip freeze` (fails to install missing packages due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_6879e48f2a0c832f97dfb01abd26090e