### PR TITLE
Add minimal backend tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install frontend deps
+        run: |
+          cd packages/frontend
+          pnpm install
+
+      - name: Build frontend
+        run: |
+          cd packages/frontend
+          pnpm build
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install backend deps
+        run: |
+          cd packages/backend
+          pip install -r requirements.txt
+          pip install pytest httpx
+
+      - name: Run tests
+        run: |
+          PYTHONPATH=packages/backend pytest -q

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+# Ensure backend modules can be imported
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "packages" / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import main as backend_main  # type: ignore  # noqa: E402
+
+
+def test_read_root():
+    client = TestClient(backend_main.app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "Backend running"}
+
+
+def test_ask_endpoint(monkeypatch):
+    class DummyOrchestrator:
+        def run(self, question: str) -> str:
+            return "dummy answer"
+
+    monkeypatch.setattr(backend_main, "Orchestrator", DummyOrchestrator)
+    client = TestClient(backend_main.app)
+    resp = client.post("/ask", json={"question": "test"})
+    assert resp.status_code == 200
+    assert resp.json() == {"answer": "dummy answer"}


### PR DESCRIPTION
## Summary
- add basic FastAPI tests for `/` and `/ask` endpoints
- set up GitHub Actions to build the frontend and run backend tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6879e805bb20832f83ed02215573d2db