### PR TITLE
Add configurable logger to frontend

### DIFF
--- a/packages/frontend/app/page.tsx
+++ b/packages/frontend/app/page.tsx
@@ -25,6 +25,7 @@ import ChatMessages from "@/components/chat/ChatMessages"
 import WelcomeScreen from "@/components/chat/WelcomeScreen"
 import ChatInputForm from "@/components/chat/ChatInputForm"
 import ErrorBoundary from "@/components/ErrorBoundary"
+import { logger } from "@/lib/logger"
 
 /* ------------- Slide transition that always keeps node mounted -------- */
 
@@ -40,20 +41,6 @@ const Transition = React.forwardRef(function Transition(
 interface Suggestion {
   title: string
   prompt: string
-}
-
-const logger = {
-  info: (message: string, data?: any) =>
-    console.log(JSON.stringify({ level: "info", timestamp: new Date().toISOString(), message, data })),
-  error: (message: string, error?: any) =>
-    console.error(
-      JSON.stringify({
-        level: "error",
-        timestamp: new Date().toISOString(),
-        message,
-        error: error ? { message: error.message, stack: error.stack } : "No error object",
-      }),
-    ),
 }
 
 /* ============================= PAGE =================================== */

--- a/packages/frontend/components/ErrorBoundary.tsx
+++ b/packages/frontend/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Box, Typography } from "@mui/material"
+import { logger } from "@/lib/logger"
 
 interface ErrorBoundaryProps {
   children: React.ReactNode
@@ -24,7 +25,7 @@ export default class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("ErrorBoundary caught an error", error, errorInfo)
+    logger.error("ErrorBoundary caught an error", { error, errorInfo })
   }
 
   render() {

--- a/packages/frontend/lib/logger.ts
+++ b/packages/frontend/lib/logger.ts
@@ -1,0 +1,61 @@
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug'
+
+const LEVEL_MAP: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+}
+
+function getCurrentLevel(): number {
+  const envLevel = process.env.NEXT_PUBLIC_LOG_LEVEL as LogLevel | undefined
+  if (envLevel && envLevel in LEVEL_MAP) {
+    return LEVEL_MAP[envLevel]
+  }
+  return process.env.NODE_ENV === 'production' ? LEVEL_MAP.error : LEVEL_MAP.debug
+}
+
+const CURRENT_LEVEL = getCurrentLevel()
+
+function emit(level: LogLevel, message: string, data?: any) {
+  if (LEVEL_MAP[level] > CURRENT_LEVEL) return
+
+  const payload: Record<string, any> = {
+    level,
+    timestamp: new Date().toISOString(),
+    message,
+  }
+
+  if (data !== undefined) {
+    payload.data = data
+  }
+
+  const serialized = JSON.stringify(payload)
+
+  switch (level) {
+    case 'error':
+      console.error(serialized)
+      break
+    case 'warn':
+      console.warn(serialized)
+      break
+    default:
+      console.log(serialized)
+  }
+}
+
+export const logger = {
+  error: (message: string, error?: any) =>
+    emit(
+      'error',
+      message,
+      error instanceof Error
+        ? { message: error.message, stack: error.stack }
+        : error,
+    ),
+  warn: (message: string, data?: any) => emit('warn', message, data),
+  info: (message: string, data?: any) => emit('info', message, data),
+  debug: (message: string, data?: any) => emit('debug', message, data),
+}
+
+export default logger


### PR DESCRIPTION
## Summary
- implement a simple logger utility for the frontend with log levels that respect environment configuration
- use the new logger in the main chat page and in the error boundary component

## Testing
- `npm --prefix packages/frontend run lint` *(fails: `next` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6879e8c71bf0832fa17d4a7bf2aea0ef