### PR TITLE
Refactor Chat component with hooks

### DIFF
--- a/packages/frontend/components/chat/AboutDialog.tsx
+++ b/packages/frontend/components/chat/AboutDialog.tsx
@@ -1,0 +1,42 @@
+"use client"
+import React from "react"
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  Slide,
+} from "@mui/material"
+import type { TransitionProps } from "@mui/material/transitions"
+import type { ReactElement } from "react"
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & { children: ReactElement<any, any> },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />
+})
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export default function AboutDialog({ open, onClose }: Props) {
+  return (
+    <Dialog open={open} onClose={onClose} TransitionComponent={Transition} keepMounted>
+      <DialogTitle>About ABACUS</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          ABACUS is an intelligent assistant designed to help you navigate the Ameritas technology landscape. Query
+          our repository for information on approved technologies, standards, and best practices.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/packages/frontend/hooks/use-chat-scroll.ts
+++ b/packages/frontend/hooks/use-chat-scroll.ts
@@ -1,0 +1,25 @@
+"use client"
+import { useRef, useCallback, useEffect } from "react"
+import { logger } from "@/lib/logger"
+
+export function useChatScroll(deps: any[]) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const scrollToBottom = useCallback(() => {
+    if (!containerRef.current) return
+    try {
+      containerRef.current.scrollTo({
+        top: containerRef.current.scrollHeight,
+        behavior: "smooth",
+      })
+    } catch (e) {
+      logger.error("scrollToBottom failed", e)
+    }
+  }, [])
+
+  useEffect(() => {
+    scrollToBottom()
+  }, [...deps, scrollToBottom])
+
+  return containerRef
+}

--- a/packages/frontend/hooks/use-chat.ts
+++ b/packages/frontend/hooks/use-chat.ts
@@ -1,0 +1,72 @@
+"use client"
+import { useState, useCallback } from "react"
+import { logger } from "@/lib/logger"
+
+export interface Message {
+  id: string
+  role: string
+  content: string
+}
+
+export function useChat() {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value)
+  }, [])
+
+  const handleSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const question = input.trim()
+    if (!question) return
+
+    const userMessage: Message = { id: `user-${Date.now()}`, role: "user", content: question }
+    setMessages(prev => [...prev, userMessage])
+    setInput("")
+
+    setIsLoading(true)
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+
+    try {
+      const res = await fetch(`${apiUrl}/ask`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question }),
+      })
+      const data = await res.json()
+      const assistantMessage: Message = {
+        id: `assistant-${Date.now()}`,
+        role: "assistant",
+        content: data.answer,
+      }
+      setMessages(prev => [...prev, assistantMessage])
+    } catch (error: any) {
+      logger.error("Chat submission failed", error)
+      const errorMessage: Message = {
+        id: `error-${Date.now()}`,
+        role: "system",
+        content: `I'm sorry, but I've encountered an issue. Please check your connection or try again later. \n\n**Error:** ${error.message}`,
+      }
+      setMessages(prev => [...prev, errorMessage])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [input])
+
+  const queryHistory = messages
+    .filter((m) => m.role === "user")
+    .map((m) => ({ id: m.id, content: m.content }))
+
+  return {
+    messages,
+    input,
+    isLoading,
+    handleInputChange,
+    handleSubmit,
+    setMessages,
+    setInput,
+    queryHistory,
+  }
+}

--- a/packages/frontend/hooks/use-suggestions.ts
+++ b/packages/frontend/hooks/use-suggestions.ts
@@ -1,0 +1,21 @@
+"use client"
+import { useState, useEffect } from "react"
+import { logger } from "@/lib/logger"
+
+export interface Suggestion {
+  title: string
+  prompt: string
+}
+
+export function useSuggestions() {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+
+  useEffect(() => {
+    fetch("/prompts.json")
+      .then((res) => res.json())
+      .then((data) => setSuggestions(data.suggestions))
+      .catch((err) => logger.error("Failed to load suggestions", err))
+  }, [])
+
+  return suggestions
+}


### PR DESCRIPTION
## Summary
- add AboutDialog component
- add chat-related hooks to manage state and suggestions
- simplify Chat component to use the new hooks and AboutDialog

## Testing
- `pnpm lint` *(fails: next not found)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6879eacae608832f8b424afb94752168