### PR TITLE
Centralize config and parameterize UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,10 @@ ABACUS_TIMEOUT=15
 # SSL verification for external services
 VERIFY_SSL=true
 
+# Application settings
+APP_NAME=AskABACUS
+APP_LOGO=/images/ameritas-logo.png
+ALLOWED_ORIGINS=http://localhost:3000
+
 # Frontend configuration
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ backend requires AWS Bedrock and ABACUS settings:
 The service exposes a POST `/ask` endpoint used by the frontend to retrieve
 answers. Point the frontend to the backend by setting `NEXT_PUBLIC_API_URL`
 in `packages/frontend/.env` (see `packages/frontend/.env.example`).
+Additional optional settings let you customize the application name and logo:
+
+- `APP_NAME` and `NEXT_PUBLIC_APP_NAME`
+- `APP_LOGO` and `NEXT_PUBLIC_APP_LOGO`
+- `ALLOWED_ORIGINS` for CORS configuration
 
 ## How It Works
 

--- a/packages/backend/abacus_client.py
+++ b/packages/backend/abacus_client.py
@@ -2,25 +2,32 @@
 
 from __future__ import annotations
 
-import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
+
+from env import settings
 
 
 class AbacusClient:
     """HTTP client for the ABACUS recommendation service."""
 
-    def __init__(self) -> None:
-        self.base_url = os.getenv("ABACUS_BASE_URL", "").rstrip("/")
-        self.client_secret = os.getenv("ABACUS_CLIENT_SECRET", "")
-        self.timeout = int(os.getenv("ABACUS_TIMEOUT", "15"))
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        timeout: Optional[int] = None,
+        verify_ssl: Optional[bool] = None,
+    ) -> None:
+        self.base_url = (base_url or settings.ABACUS_BASE_URL).rstrip("/")
+        self.client_secret = client_secret or settings.ABACUS_CLIENT_SECRET
+        self.timeout = timeout if timeout is not None else settings.ABACUS_TIMEOUT
         # Honor VERIFY_SSL=false to allow self-signed certificates during development
-        self.verify_ssl = os.getenv("VERIFY_SSL", "true").lower() not in {
-            "0",
-            "false",
-            "no",
-        }
+        self.verify_ssl = (
+            verify_ssl
+            if verify_ssl is not None
+            else settings.VERIFY_SSL
+        )
 
         self._headers = {
             "Authorization": f"Bearer {self.client_secret}",

--- a/packages/backend/bedrock_adapter.py
+++ b/packages/backend/bedrock_adapter.py
@@ -2,28 +2,40 @@
 
 from __future__ import annotations
 
-import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
+
+from env import settings
 
 
 class BedrockAdapter:
     """HTTP adapter for AWS Bedrock using the OpenAI chat format."""
 
-    def __init__(self) -> None:
-        self.api_base = os.getenv("BEDROCK_API_BASE", "").rstrip("/")
-        self.api_key = os.getenv("BEDROCK_API_KEY", "")
-        self.model_id = os.getenv("BEDROCK_MODEL_ID", "")
-        self.timeout = int(os.getenv("BEDROCK_TIMEOUT", "15"))
-        self.max_tokens = int(os.getenv("BEDROCK_MAX_TOKENS", "2048"))
-        self.temperature = float(os.getenv("BEDROCK_TEMPERATURE", "0.7"))
+    def __init__(
+        self,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        model_id: Optional[str] = None,
+        timeout: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        verify_ssl: Optional[bool] = None,
+    ) -> None:
+        self.api_base = (api_base or settings.BEDROCK_API_BASE).rstrip("/")
+        self.api_key = api_key or settings.BEDROCK_API_KEY
+        self.model_id = model_id or settings.BEDROCK_MODEL_ID
+        self.timeout = timeout if timeout is not None else settings.BEDROCK_TIMEOUT
+        self.max_tokens = (
+            max_tokens if max_tokens is not None else settings.BEDROCK_MAX_TOKENS
+        )
+        self.temperature = (
+            temperature if temperature is not None else settings.BEDROCK_TEMPERATURE
+        )
         # Honor VERIFY_SSL=false to allow self-signed certificates during development
-        self.verify_ssl = os.getenv("VERIFY_SSL", "true").lower() not in {
-            "0",
-            "false",
-            "no",
-        }
+        self.verify_ssl = (
+            verify_ssl if verify_ssl is not None else settings.VERIFY_SSL
+        )
 
         self._headers = {
             "Authorization": f"Bearer {self.api_key}",

--- a/packages/backend/env.py
+++ b/packages/backend/env.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class Settings:
+    """Application configuration loaded from environment variables."""
+
+    # Bedrock
+    BEDROCK_API_BASE: str = os.getenv("BEDROCK_API_BASE", "").rstrip("/")
+    BEDROCK_API_KEY: str = os.getenv("BEDROCK_API_KEY", "")
+    BEDROCK_MODEL_ID: str = os.getenv("BEDROCK_MODEL_ID", "")
+    BEDROCK_TIMEOUT: int = int(os.getenv("BEDROCK_TIMEOUT", "15"))
+    BEDROCK_MAX_TOKENS: int = int(os.getenv("BEDROCK_MAX_TOKENS", "2048"))
+    BEDROCK_TEMPERATURE: float = float(os.getenv("BEDROCK_TEMPERATURE", "0.7"))
+
+    # ABACUS
+    ABACUS_BASE_URL: str = os.getenv("ABACUS_BASE_URL", "").rstrip("/")
+    ABACUS_CLIENT_SECRET: str = os.getenv("ABACUS_CLIENT_SECRET", "")
+    ABACUS_TIMEOUT: int = int(os.getenv("ABACUS_TIMEOUT", "15"))
+
+    # Misc
+    VERIFY_SSL: bool = os.getenv("VERIFY_SSL", "true").lower() not in {"0", "false", "no"}
+
+    # FastAPI
+    ALLOWED_ORIGINS: str = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
+
+    # UI
+    APP_NAME: str = os.getenv("APP_NAME", "AskABACUS")
+    APP_LOGO: str = os.getenv("APP_LOGO", "/images/ameritas-logo.png")
+
+
+settings = Settings()

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -3,12 +3,14 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from orchestrator import Orchestrator
+from env import settings
 
 app = FastAPI()
 
+origins = [o.strip() for o in settings.ALLOWED_ORIGINS.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,1 +1,3 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_APP_NAME=AskABACUS
+NEXT_PUBLIC_APP_LOGO=/images/ameritas-logo.png

--- a/packages/frontend/app/faq/page.tsx
+++ b/packages/frontend/app/faq/page.tsx
@@ -2,12 +2,13 @@
 import { Container, Typography, Accordion, AccordionSummary, AccordionDetails, Box, Button, Paper } from "@mui/material"
 import { ExpandMore, ArrowBack } from "@mui/icons-material"
 import Link from "next/link"
+import { APP_NAME } from "@/lib/config"
 
 const faqData = [
   {
-    question: "What is ABACUS?",
+    question: `What is ${APP_NAME}?`,
     answer:
-      "ABACUS is an intelligent assistant designed to help you navigate the Ameritas technology landscape. You can ask it about approved technologies, standards, versions, and best practices.",
+      `${APP_NAME} is an intelligent assistant designed to help you navigate the Ameritas technology landscape. You can ask it about approved technologies, standards, versions, and best practices.`,
   },
   {
     question: "How do I start a new chat?",
@@ -22,7 +23,7 @@ const faqData = [
   {
     question: "Are the AI's responses always accurate?",
     answer:
-      "While ABACUS is a powerful tool, some responses may not be 100% accurate or up-to-date. It's always a good practice to verify critical information through official documentation or by consulting with a subject matter expert.",
+      `While ${APP_NAME} is a powerful tool, some responses may not be 100% accurate or up-to-date. It's always a good practice to verify critical information through official documentation or by consulting with a subject matter expert.`,
   },
   {
     question: "How do I use the suggested prompts?",
@@ -45,7 +46,7 @@ export default function FaqPage() {
           Frequently Asked Questions
         </Typography>
         <Typography variant="h6" color="text.secondary" sx={{ textAlign: "center", mb: 5 }}>
-          Need help? Here are some common questions about ABACUS.
+          Need help? Here are some common questions about {APP_NAME}.
         </Typography>
 
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>

--- a/packages/frontend/app/layout.tsx
+++ b/packages/frontend/app/layout.tsx
@@ -3,16 +3,17 @@ import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
 import ThemeRegistry from "@/components/providers/theme-registry"
+import { APP_NAME, APP_LOGO } from "@/lib/config"
 
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "ABACUS - Ameritas",
+  title: `${APP_NAME} - Ameritas`,
   description: "An intelligent assistant for technology insights, powered by Ameritas.",
   icons: {
-    icon: "/images/ameritas-logo.png",
+    icon: APP_LOGO,
   },
-    generator: 'v0.dev'
+  generator: 'v0.dev'
 }
 
 export default function RootLayout({

--- a/packages/frontend/app/page.tsx
+++ b/packages/frontend/app/page.tsx
@@ -18,6 +18,7 @@ import WelcomeScreen from "@/components/chat/WelcomeScreen"
 import ChatInputForm from "@/components/chat/ChatInputForm"
 import ErrorBoundary from "@/components/ErrorBoundary"
 import AboutDialog from "@/components/chat/AboutDialog"
+import { APP_NAME, APP_LOGO } from "@/lib/config"
 import { useChat } from "@/hooks/use-chat"
 import { useSuggestions } from "@/hooks/use-suggestions"
 import { useChatScroll } from "@/hooks/use-chat-scroll"
@@ -112,8 +113,8 @@ export function Chat() {
                   }}
                 >
                   <img
-                    src="/images/ameritas-logo.png"
-                    alt="ABACUS Logo"
+                    src={APP_LOGO}
+                    alt={`${APP_NAME} Logo`}
                     style={{
                       maxWidth: "100%",
                       maxHeight: "100%",
@@ -128,7 +129,7 @@ export function Chat() {
                     fontWeight: "bold",
                   }}
                 >
-                  ABACUS
+                  {APP_NAME}
                 </Typography>
               </Box>
             </Toolbar>

--- a/packages/frontend/components/chat/AboutDialog.tsx
+++ b/packages/frontend/components/chat/AboutDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material"
 import type { TransitionProps } from "@mui/material/transitions"
 import type { ReactElement } from "react"
+import { APP_NAME } from "@/lib/config"
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & { children: ReactElement<any, any> },
@@ -27,10 +28,10 @@ interface Props {
 export default function AboutDialog({ open, onClose }: Props) {
   return (
     <Dialog open={open} onClose={onClose} TransitionComponent={Transition} keepMounted>
-      <DialogTitle>About ABACUS</DialogTitle>
+      <DialogTitle>About {APP_NAME}</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          ABACUS is an intelligent assistant designed to help you navigate the Ameritas technology landscape. Query
+          {APP_NAME} is an intelligent assistant designed to help you navigate the Ameritas technology landscape. Query
           our repository for information on approved technologies, standards, and best practices.
         </DialogContentText>
       </DialogContent>

--- a/packages/frontend/components/chat/ChatMessages.tsx
+++ b/packages/frontend/components/chat/ChatMessages.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm"
 import ProcessingIndicator from "@/components/chat/ProcessingIndicator"
 import ErrorMessage from "@/components/chat/ErrorMessage"
 import { fadeIn } from "@/components/chat/animations"
+import { APP_NAME, APP_LOGO } from "@/lib/config"
 
 interface Message {
   id: string
@@ -47,8 +48,8 @@ export default function ChatMessages({ messages, isLoading }: Props) {
                 }}
               >
                 <img
-                  src="/images/ameritas-logo.png"
-                  alt="ABACUS"
+                  src={APP_LOGO}
+                  alt={APP_NAME}
                   style={{ width: "70%", height: "70%", objectFit: "contain" }}
                 />
               </Avatar>

--- a/packages/frontend/components/chat/ProcessingIndicator.tsx
+++ b/packages/frontend/components/chat/ProcessingIndicator.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react"
 import { Avatar, Box, CircularProgress, Paper, Typography } from "@mui/material"
 import { fadeIn, textFadeIn } from "./animations"
+import { APP_NAME, APP_LOGO } from "@/lib/config"
 
 export default function ProcessingIndicator() {
   const statuses = [
@@ -50,8 +51,8 @@ export default function ProcessingIndicator() {
         }}
       >
         <img
-          src="/images/ameritas-logo.png"
-          alt="ABACUS"
+          src={APP_LOGO}
+          alt={APP_NAME}
           style={{ width: "70%", height: "70%", objectFit: "contain" }}
         />
       </Avatar>

--- a/packages/frontend/components/chat/SidebarContent.tsx
+++ b/packages/frontend/components/chat/SidebarContent.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mui/material"
 import { Add, PersonOutline, History, InfoOutlined } from "@mui/icons-material"
 import { fadeIn } from "./animations"
+import { APP_NAME, APP_LOGO } from "@/lib/config"
 
 interface Props {
   queryHistory: { id: string; content: string }[]
@@ -62,18 +63,20 @@ export default function SidebarContent({
           }}
         >
           {logoFailedToLoad ? (
-            <span style={{ color: "white", fontWeight: "bold", fontSize: 14 }}>A</span>
+            <span style={{ color: "white", fontWeight: "bold", fontSize: 14 }}>
+              {APP_NAME.charAt(0)}
+            </span>
           ) : (
             <img
-              src="/images/ameritas-logo.png"
-              alt="ABACUS Logo"
+              src={APP_LOGO}
+              alt={`${APP_NAME} Logo`}
               style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
               onError={() => setLogoFailedToLoad(true)}
             />
           )}
         </Box>
         <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-          ABACUS
+          {APP_NAME}
         </Typography>
       </Box>
 

--- a/packages/frontend/components/chat/WelcomeScreen.tsx
+++ b/packages/frontend/components/chat/WelcomeScreen.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { Box, Grid, Paper, Typography } from "@mui/material"
 import { Add } from "@mui/icons-material"
 import { fadeIn } from "@/components/chat/animations"
+import { APP_NAME } from "@/lib/config"
 
 interface Suggestion {
   title: string
@@ -30,7 +31,7 @@ export default function WelcomeScreen({ suggestions, onSuggestionClick }: Props)
       }}
     >
       <Typography variant="h3" component="h1" gutterBottom sx={{ fontWeight: "bold" }}>
-        Welcome to ABACUS
+        Welcome to {APP_NAME}
       </Typography>
       <Typography variant="h6" color="text.secondary" sx={{ mb: 4 }}>
         Your intelligent assistant for navigating the Ameritas technology landscape.

--- a/packages/frontend/lib/config.ts
+++ b/packages/frontend/lib/config.ts
@@ -1,0 +1,2 @@
+export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME || 'AskABACUS'
+export const APP_LOGO = process.env.NEXT_PUBLIC_APP_LOGO || '/images/ameritas-logo.png'


### PR DESCRIPTION
## Summary
- add `env.py` to load environment variables in one place
- parameterize `BedrockAdapter` and `AbacusClient` with settings
- read CORS origins from `ALLOWED_ORIGINS`
- expose `APP_NAME` and logo via `config.ts` for frontend
- inject configurable app name and logo across frontend
- document new environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6879ee4acf70832f94c3a12e3563fec0