### PR TITLE
Add scripts for local build and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ pip install -r requirements.txt
 python main.py
 ```
 
+### Local build and run
+
+To install dependencies, build the frontend, and start both services, run
+`deploy_local.sh` on Linux or `deploy_local.bat` on Windows. The scripts
+create a Python virtual environment in `packages/backend/.venv` if needed:
+
+```bash
+./deploy_local.sh
+```
+
+The scripts launch the backend on port `8000` and the frontend on
+`http://localhost:3000`.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and provide values for the following settings:

--- a/deploy_local.bat
+++ b/deploy_local.bat
@@ -1,0 +1,21 @@
+@echo off
+rem Build and run the frontend and backend locally without Docker.
+rem Usage: deploy_local.bat
+
+pushd %~dp0\packages\frontend
+pnpm install
+pnpm build
+start "frontend" pnpm start
+popd
+
+pushd %~dp0\packages\backend
+if not exist .venv (
+    python -m venv .venv
+)
+call .venv\Scripts\activate
+pip install -r requirements.txt
+start "backend" python main.py
+deactivate
+popd
+
+echo Services started. Press Ctrl+C in each window to stop.

--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build and run the frontend and backend locally without Docker.
+# Usage: ./deploy_local.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+pushd packages/frontend
+pnpm install
+pnpm build
+pnpm start &
+FRONTEND_PID=$!
+popd
+
+pushd packages/backend
+if [ ! -d .venv ]; then
+    python3 -m venv .venv
+fi
+source .venv/bin/activate
+pip install -r requirements.txt
+python main.py &
+BACKEND_PID=$!
+deactivate
+popd
+
+trap "kill $FRONTEND_PID $BACKEND_PID" EXIT
+wait $FRONTEND_PID $BACKEND_PID


### PR DESCRIPTION
## Summary
- run both services locally without Docker via `deploy_local.(sh|bat)`
- explain the new workflow in the README
- create a Python virtual environment automatically when starting the backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_687a34626df4832f8b817348358e8456