### PR TITLE
Load catalog via Abacus API

### DIFF
--- a/packages/backend/abacus_client.py
+++ b/packages/backend/abacus_client.py
@@ -71,3 +71,26 @@ class AbacusClient:
             raise RuntimeError(
                 "Unexpected response structure from ABACUS service"
             ) from exc
+
+    def query_data(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        """Fetch JSON data from the ABACUS API using OData query parameters."""
+
+        if not self.base_url or not self.client_secret:
+            raise RuntimeError("ABACUS API credentials are not configured")
+
+        url = f"{self.base_url}/{endpoint.lstrip('/') }"
+        try:
+            response = requests.get(
+                url,
+                headers=self._headers,
+                params=params or {},
+                timeout=self.timeout,
+                verify=self.verify_ssl,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("value", data)
+        except requests.RequestException as exc:  # pragma: no cover - network
+            raise RuntimeError("Failed to query ABACUS service") from exc
+        except ValueError as exc:  # pragma: no cover - unlikely
+            raise RuntimeError("Invalid response from ABACUS service") from exc

--- a/packages/backend/orchestrator.py
+++ b/packages/backend/orchestrator.py
@@ -125,9 +125,9 @@ class Orchestrator:
                 print(f"Failed to load vector store: {exc}. Rebuilding index.")
 
         if not index_loaded:
-            # Fallback: load data and build the index, persisting it for later use.
-            self.capabilities = self._load_capabilities()
-            self.applications = self._load_applications()
+            # Fallback: fetch data and build the index, persisting it for later use.
+            self.capabilities = self.client.query_data("capabilities")
+            self.applications = self.client.query_data("applications")
             texts = [
                 e.get("description", "")
                 for e in self.capabilities + self.applications
@@ -159,17 +159,6 @@ class Orchestrator:
 
         self.__class__._initialized = True
 
-    def _load_capabilities(self) -> List[Dict[str, str]]:
-        """Load technology capabilities from the JSON catalog."""
-        path = Path(__file__).with_name("technology_capabilities.json")
-        if not path.exists():
-            return []
-        with path.open("r", encoding="utf-8") as fh:
-            records = json.load(fh)
-            if isinstance(records, list):
-                return records
-        return []
-
     def _build_capability_index(
         self, capabilities: List[Dict[str, str]]
     ) -> Tuple[faiss.Index, List[str]]:
@@ -185,17 +174,6 @@ class Orchestrator:
 
     # ------------------------------------------------------------------
     # Application catalog utilities
-
-    def _load_applications(self) -> List[Dict[str, str]]:
-        """Load application records from the JSON catalog."""
-        path = Path(__file__).with_name("applications.json")
-        if not path.exists():
-            return []
-        with path.open("r", encoding="utf-8") as fh:
-            records = json.load(fh)
-            if isinstance(records, list):
-                return records
-        return []
 
     def _build_application_index(
         self, applications: List[Dict[str, str]]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "packages" / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import orchestrator as orch_module  # type: ignore
+
+
+def test_orchestrator_fetches_catalog(monkeypatch):
+    vector_dir = BACKEND_DIR / "vector_store"
+    if vector_dir.exists():
+        for item in vector_dir.iterdir():
+            item.unlink()
+        vector_dir.rmdir()
+
+    monkeypatch.setattr(
+        orch_module.SentenceTransformer,
+        "encode",
+        lambda self, texts, convert_to_numpy=True: np.ones((len(texts), 1), dtype="float32"),
+    )
+    monkeypatch.setattr(orch_module.faiss, "write_index", lambda index, path: None)
+
+    calls = []
+
+    def fake_query_data(self, endpoint, params=None):
+        calls.append(endpoint)
+        if endpoint == "capabilities":
+            return [{"id": "cap1", "name": "Cap", "category": "cat", "description": "desc"}]
+        if endpoint == "applications":
+            return [
+                {
+                    "id": "app1",
+                    "name": "App",
+                    "description": "desc",
+                    "technologies": ["Cap"],
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(orch_module.AbacusClient, "query_data", fake_query_data)
+
+    orch_module.Orchestrator()
+
+    assert "capabilities" in calls
+    assert "applications" in calls
+
+    if vector_dir.exists():
+        for item in vector_dir.iterdir():
+            item.unlink()
+        vector_dir.rmdir()


### PR DESCRIPTION
## Summary
- add AbacusClient.query_data for generic OData queries
- pull capabilities and applications from the API when building the vector store
- drop JSON file loading helpers
- add unit test verifying catalog data is fetched from AbacusClient

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687a479939d0832f8feb5a73b8aecf56