### PR TITLE
Implement BedrockOpenAI style adapter

### DIFF
--- a/packages/backend/bedrock_adapter.py
+++ b/packages/backend/bedrock_adapter.py
@@ -68,18 +68,32 @@ class BedrockAdapter:
     # ------------------------------------------------------------------
     # Public API used by the orchestrator
 
+    def create(
+        self,
+        model: Optional[str],
+        messages: List[Dict[str, str]],
+        *,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Return a response dict in the OpenAI chat format."""
+
+        payload = {
+            "model": model or self.model_id,
+            "messages": messages,
+            "max_tokens": max_tokens if max_tokens is not None else self.max_tokens,
+            "temperature": (
+                temperature if temperature is not None else self.temperature
+            ),
+        }
+
+        return self._request(payload)
+
     def invoke(self, prompt: str) -> str:
         """Send ``prompt`` and return the model's completion text."""
 
         messages: List[Dict[str, str]] = [{"role": "user", "content": prompt}]
-        payload = {
-            "model": self.model_id,
-            "messages": messages,
-            "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
-        }
-
-        data = self._request(payload)
+        data = self.create(self.model_id, messages)
         try:
             return data["choices"][0]["message"]["content"]
         except (KeyError, IndexError) as exc:

--- a/tests/test_bedrock_adapter.py
+++ b/tests/test_bedrock_adapter.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+# Ensure backend modules can be imported
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "packages" / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import bedrock_adapter  # type: ignore
+
+
+def test_create_returns_chat_format(monkeypatch):
+    adapter = bedrock_adapter.BedrockAdapter(
+        api_base="http://bedrock", api_key="key", model_id="model"
+    )
+
+    captured = {}
+
+    def fake_request(payload):
+        captured["payload"] = payload
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(adapter, "_request", fake_request)
+
+    messages = [{"role": "user", "content": "hi"}]
+    resp = adapter.create("model", messages)
+
+    assert captured["payload"]["model"] == "model"
+    assert captured["payload"]["messages"] == messages
+    assert resp["choices"][0]["message"]["content"] == "ok"


### PR DESCRIPTION
## Summary
- add `create` API to `BedrockAdapter` for OpenAI-style chat completions
- use the new API in orchestrator for query planning and answer synthesis
- test that `create` returns a proper OpenAI chat response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687a4b268d3c832fa9817029550cd2c7