### PR TITLE
Improve system prompt usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ Copy `.env.example` to `.env` and provide values for the following settings:
 - Suggested prompts loaded from `public/prompts.json`
 - FAQ page at `/faq`
 - UI components from the Shadcn library without using the CLI
+- Agentic orchestration with supervisor, worker, and reviewer roles
+- Basic short-term and long-term memory for conversations

--- a/packages/backend/memory.py
+++ b/packages/backend/memory.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+class ShortTermMemory:
+    """In-memory storage of the recent conversation."""
+
+    def __init__(self, limit: int = 5) -> None:
+        self.limit = limit
+        self.messages: List[Dict[str, str]] = []
+
+    def add(self, role: str, content: str) -> None:
+        self.messages.append({"role": role, "content": content})
+        # Trim to the last ``limit`` messages
+        if len(self.messages) > self.limit:
+            self.messages = self.messages[-self.limit :]
+
+    def context(self) -> List[Dict[str, str]]:
+        return list(self.messages)
+
+
+class LongTermMemory:
+    """Simple file-based memory for persisting conversations."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._messages: List[Dict[str, str]] = []
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            try:
+                with self.path.open("r", encoding="utf-8") as fh:
+                    self._messages = json.load(fh)
+            except Exception:
+                self._messages = []
+
+    def _save(self) -> None:
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(self._messages, fh, indent=2)
+
+    def add(self, role: str, content: str) -> None:
+        self._messages.append({"role": role, "content": content})
+        self._save()
+
+    def all_messages(self) -> List[Dict[str, str]]:
+        return list(self._messages)

--- a/packages/backend/prompt_library.py
+++ b/packages/backend/prompt_library.py
@@ -1,0 +1,30 @@
+PROMPTS = {
+    "planner": (
+        "You generate search keywords for the technology catalog. "
+        "Given a user request, respond with JSON containing a single key 'query'. "
+        "Return **only** the JSON object."
+    ),
+    "synthesizer": (
+        "You are an assistant that turns ranked applications into a helpful "
+        "answer. Using the provided list and user question, generate a short "
+        "Markdown response describing the most relevant applications as a "
+        "bullet list."
+    ),
+    "ranker": (
+        "Rank the following applications in relevance to the user query. "
+        "Return a JSON list of application IDs ordered most to least relevant."
+    ),
+    "reviewer": (
+        "Review the worker's answer for clarity and correctness. "
+        "Return the improved final answer in Markdown."
+    ),
+    "supervisor": (
+        "Coordinate the workers to fulfill the user request. "
+        "Use planning prompts and ensure the workflow is followed."
+    ),
+}
+
+
+def get_prompt(name: str) -> str:
+    """Return the prompt text identified by ``name``."""
+    return PROMPTS.get(name, "")


### PR DESCRIPTION
## Summary
- use a helper to call the language model with explicit `system` and `user` roles
- replace embedded prompts in `Orchestrator` with properly formatted messages
- add a prompt library and simple memory modules
- store long-term memory to disk and keep short-term history in memory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687a5048f054832f8edb7aeb9cf4dd77