### PR TITLE
Switch long term memory to SQLite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,8 @@ APP_NAME=AskABACUS
 APP_LOGO=/images/ameritas-logo.png
 ALLOWED_ORIGINS=http://localhost:3000
 
+# Optional: path to the SQLite database used for long-term memory
+LONG_TERM_DB_PATH=packages/backend/memory/long_term.db
+
 # Frontend configuration
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -61,3 +61,10 @@ Copy `.env.example` to `.env` and provide values for the following settings:
 - UI components from the Shadcn library without using the CLI
 - Agentic orchestration with supervisor, worker, and reviewer roles
 - Basic short-term and long-term memory for conversations
+
+### Migration notes
+
+Long-term memory is now stored in an SQLite database located at
+`packages/backend/memory/long_term.db` by default. Previous versions used a
+`long_term.json` file. The service will create the new database automatically.
+To use a custom location, set the `LONG_TERM_DB_PATH` environment variable.

--- a/packages/backend/env.py
+++ b/packages/backend/env.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
+from pathlib import Path
 
 
 @dataclass
@@ -30,6 +31,12 @@ class Settings:
     # UI
     APP_NAME: str = os.getenv("APP_NAME", "AskABACUS")
     APP_LOGO: str = os.getenv("APP_LOGO", "/images/ameritas-logo.png")
+
+    # Memory
+    LONG_TERM_DB_PATH: str = os.getenv(
+        "LONG_TERM_DB_PATH",
+        str(Path(__file__).with_name("memory") / "long_term.db"),
+    )
 
 
 settings = Settings()

--- a/packages/backend/orchestrator.py
+++ b/packages/backend/orchestrator.py
@@ -12,7 +12,9 @@ from sentence_transformers import SentenceTransformer
 from abacus_client import AbacusClient
 from bedrock_adapter import BedrockAdapter
 from prompt_library import get_prompt
-from memory import LongTermMemory, ShortTermMemory
+from memory import ShortTermMemory
+from sqlite_memory import SQLiteMemory
+from env import settings
 
 
 # System prompt used to instruct the language model on the format of the
@@ -48,9 +50,7 @@ class Orchestrator:
             self.client = AbacusClient()
             self.adapter = BedrockAdapter()
             self.short_memory = ShortTermMemory()
-            self.long_memory = LongTermMemory(
-                Path(__file__).with_name("memory") / "long_term.json"
-            )
+            self.long_memory = SQLiteMemory(Path(settings.LONG_TERM_DB_PATH))
             self._vector_model = self.__class__._vector_model
             self.index = self.__class__._index
             self.entries = self.__class__._entries
@@ -62,9 +62,7 @@ class Orchestrator:
         self.client = AbacusClient()
         self.adapter = BedrockAdapter()
         self.short_memory = ShortTermMemory()
-        self.long_memory = LongTermMemory(
-            Path(__file__).with_name("memory") / "long_term.json"
-        )
+        self.long_memory = SQLiteMemory(Path(settings.LONG_TERM_DB_PATH))
 
         if self.__class__._vector_model is None:
             self.__class__._vector_model = SentenceTransformer("all-MiniLM-L6-v2")

--- a/packages/backend/sqlite_memory.py
+++ b/packages/backend/sqlite_memory.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+class SQLiteMemory:
+    """SQLite-backed persistent memory for conversations."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(self.path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add(self, role: str, content: str) -> int:
+        """Insert a new message and return its ID."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO messages (role, content) VALUES (?, ?)",
+            (role, content),
+        )
+        self.conn.commit()
+        return int(cur.lastrowid)
+
+    def get(self, message_id: int) -> Optional[Dict[str, str]]:
+        """Return a single message or ``None`` if not found."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, role, content FROM messages WHERE id = ?",
+            (message_id,),
+        )
+        row = cur.fetchone()
+        if row:
+            mid, role, content = row
+            return {"id": mid, "role": role, "content": content}
+        return None
+
+    def update(
+        self,
+        message_id: int,
+        *,
+        role: Optional[str] = None,
+        content: Optional[str] = None,
+    ) -> bool:
+        """Update the message identified by ``message_id``."""
+        if role is None and content is None:
+            return False
+        fields = []
+        params = []
+        if role is not None:
+            fields.append("role = ?")
+            params.append(role)
+        if content is not None:
+            fields.append("content = ?")
+            params.append(content)
+        params.append(message_id)
+        cur = self.conn.cursor()
+        cur.execute(
+            f"UPDATE messages SET {', '.join(fields)} WHERE id = ?",
+            params,
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
+    def delete(self, message_id: int) -> bool:
+        """Remove the message with the given ``message_id``."""
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM messages WHERE id = ?", (message_id,))
+        self.conn.commit()
+        return cur.rowcount > 0
+
+    def all_messages(self) -> List[Dict[str, str]]:
+        """Return all messages in insertion order."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, role, content FROM messages ORDER BY id")
+        rows = cur.fetchall()
+        return [
+            {"id": mid, "role": role, "content": content}
+            for mid, role, content in rows
+        ]


### PR DESCRIPTION
## Summary
- implement SQLite-based long term memory
- update Orchestrator to use SQLite instead of JSON
- allow overriding database path via `LONG_TERM_DB_PATH`
- add CRUD operations to `SQLiteMemory`
- document database migration in README
- add example env variable in `.env.example`

## Testing
- `pip install -r packages/backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement boto3==1.28.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_687a6fa97068832f89fbbdf12da91627