### PR TITLE
Add LONG_TERM_PATH setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ APP_LOGO=/images/ameritas-logo.png
 ALLOWED_ORIGINS=http://localhost:3000
 
 # Optional: path to the SQLite database used for long-term memory
-LONG_TERM_DB_PATH=packages/backend/memory/long_term.db
+LONG_TERM_PATH=packages/backend/memory/long_term.db
 
 # Frontend configuration
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Copy `.env.example` to `.env` and provide values for the following settings:
 - `ABACUS_BASE_URL` and `ABACUS_CLIENT_SECRET`
 - `VERIFY_SSL` (use `false` to allow self-signed certificates)
 - `NEXT_PUBLIC_API_URL` – URL of the backend for the frontend to call
-- Optional: `APP_NAME`, `APP_LOGO`, and `ALLOWED_ORIGINS`
+- Optional: `APP_NAME`, `APP_LOGO`, `ALLOWED_ORIGINS`, and `LONG_TERM_PATH`
 
 ## Features
 
@@ -67,4 +67,4 @@ Copy `.env.example` to `.env` and provide values for the following settings:
 Long-term memory is now stored in an SQLite database located at
 `packages/backend/memory/long_term.db` by default. Previous versions used a
 `long_term.json` file. The service will create the new database automatically.
-To use a custom location, set the `LONG_TERM_DB_PATH` environment variable.
+To use a custom location, set the `LONG_TERM_PATH` environment variable.

--- a/packages/backend/env.py
+++ b/packages/backend/env.py
@@ -33,10 +33,15 @@ class Settings:
     APP_LOGO: str = os.getenv("APP_LOGO", "/images/ameritas-logo.png")
 
     # Memory
-    LONG_TERM_DB_PATH: str = os.getenv(
-        "LONG_TERM_DB_PATH",
-        str(Path(__file__).with_name("memory") / "long_term.db"),
+    LONG_TERM_PATH: str = os.getenv(
+        "LONG_TERM_PATH",
+        os.getenv(
+            "LONG_TERM_DB_PATH",
+            str(Path(__file__).with_name("memory") / "long_term.db"),
+        ),
     )
+    # Backwards compatibility
+    LONG_TERM_DB_PATH: str = LONG_TERM_PATH
 
 
 settings = Settings()

--- a/packages/backend/orchestrator.py
+++ b/packages/backend/orchestrator.py
@@ -50,7 +50,7 @@ class Orchestrator:
             self.client = AbacusClient()
             self.adapter = BedrockAdapter()
             self.short_memory = ShortTermMemory()
-            self.long_memory = SQLiteMemory(Path(settings.LONG_TERM_DB_PATH))
+            self.long_memory = SQLiteMemory(Path(settings.LONG_TERM_PATH))
             self._vector_model = self.__class__._vector_model
             self.index = self.__class__._index
             self.entries = self.__class__._entries
@@ -62,7 +62,7 @@ class Orchestrator:
         self.client = AbacusClient()
         self.adapter = BedrockAdapter()
         self.short_memory = ShortTermMemory()
-        self.long_memory = SQLiteMemory(Path(settings.LONG_TERM_DB_PATH))
+        self.long_memory = SQLiteMemory(Path(settings.LONG_TERM_PATH))
 
         if self.__class__._vector_model is None:
             self.__class__._vector_model = SentenceTransformer("all-MiniLM-L6-v2")


### PR DESCRIPTION
## Summary
- add `LONG_TERM_PATH` env variable for long-term memory
- read `LONG_TERM_PATH` in orchestrator
- document new variable in `.env.example` and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a73f7d2cc832f8893dd662eb0bb30