### PR TITLE
Convert orchestrator endpoints to async

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -23,9 +23,9 @@ def read_root() -> dict[str, str]:
 
 
 @app.post("/ask")
-def ask_question(request: dict[str, str]) -> dict[str, str]:
+async def ask_question(request: dict[str, str]) -> dict[str, str]:
     """Run the orchestrator with the provided question."""
     question = request.get("question", "")
     orchestrator = Orchestrator()
-    answer = orchestrator.run(question)
+    answer = await orchestrator.run(question)
     return {"answer": answer}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,8 @@
 import sys
 from pathlib import Path
 
-from fastapi.testclient import TestClient
+import pytest
+from httpx import AsyncClient
 
 # Ensure backend modules can be imported
 BACKEND_DIR = Path(__file__).resolve().parents[1] / "packages" / "backend"
@@ -11,20 +12,22 @@ if str(BACKEND_DIR) not in sys.path:
 import main as backend_main  # type: ignore  # noqa: E402
 
 
-def test_read_root():
-    client = TestClient(backend_main.app)
-    resp = client.get("/")
+@pytest.mark.anyio
+async def test_read_root():
+    async with AsyncClient(app=backend_main.app, base_url="http://test") as client:
+        resp = await client.get("/")
     assert resp.status_code == 200
     assert resp.json() == {"status": "Backend running"}
 
 
-def test_ask_endpoint(monkeypatch):
+@pytest.mark.anyio
+async def test_ask_endpoint(monkeypatch):
     class DummyOrchestrator:
-        def run(self, question: str) -> str:
+        async def run(self, question: str) -> str:
             return "dummy answer"
 
     monkeypatch.setattr(backend_main, "Orchestrator", DummyOrchestrator)
-    client = TestClient(backend_main.app)
-    resp = client.post("/ask", json={"question": "test"})
+    async with AsyncClient(app=backend_main.app, base_url="http://test") as client:
+        resp = await client.post("/ask", json={"question": "test"})
     assert resp.status_code == 200
     assert resp.json() == {"answer": "dummy answer"}


### PR DESCRIPTION
## Summary
- make backend ask endpoint asynchronous
- convert orchestrator pipeline to async and await Bedrock calls
- update tests to exercise the async API

## Testing
- `PYTHONPATH=packages/backend pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687a76426a14832fae1c6c5fef658f09