### PR TITLE
Add volume for backend memory

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -2,6 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Ensure directory for persistent memory exists
+RUN mkdir -p /app/memory
+
 # Install Python dependencies
 COPY packages/backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ create a Python virtual environment in `packages/backend/.venv` if needed:
 The scripts launch the backend on port `8000` and the frontend on
 `http://localhost:3000`.
 
+### Docker Compose
+
+You can also run the application using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+The compose file defines a named volume `memory-data` that stores the
+SQLite database used for long-term memory at `/app/memory` inside the
+backend container. The volume preserves conversation history across
+container restarts.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and provide values for the following settings:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,8 @@ services:
       - .env
     ports:
       - "8000:8000"
+    volumes:
+      - memory-data:/app/memory
+
+volumes:
+  memory-data:


### PR DESCRIPTION
## Summary
- persist backend memory directory using docker volume
- ensure path exists when building the backend image
- document docker compose usage and persistent volume

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -r packages/backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a77dfc570832f9505f7b4af2fe280