### PR TITLE
Fix README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Copy `.env.example` to `.env` and provide values for the following settings:
 
 ## Features
 
-- Streaming chat responses from the `/ask` endpoint
 - Suggested prompts loaded from `public/prompts.json`
 - FAQ page at `/faq`
 - UI components from the Shadcn library without using the CLI


### PR DESCRIPTION
## Summary
- remove mention of streaming API from README since the endpoint does not stream

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx numpy requests fastapi uvicorn` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687a78d7a67c832fb610f883c94bfd00