### PR TITLE
Add architecture diagram and installation guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,42 @@
+# Installation Guide
+
+This document describes how to set up the frontend and backend for local development.
+
+## Requirements
+
+- **Node.js 18+** and [pnpm](https://pnpm.io/) for the Next.js frontend
+- **Python 3.10+** for the FastAPI backend
+- Optional: Docker and Docker Compose for containerized runs
+
+## Frontend setup
+
+```bash
+cd packages/frontend
+pnpm install
+pnpm dev
+```
+
+Access the UI at `http://localhost:3000`.
+
+## Backend setup
+
+```bash
+cd packages/backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python load_embeddings.py   # one-time
+python main.py
+```
+
+The API exposes `/ask` on port `8000` by default.
+
+## Docker Compose
+
+To build and run both services using containers:
+
+```bash
+docker-compose up --build
+```
+
+This command creates a volume named `memory-data` that stores the SQLite database used for long-term memory.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,31 @@
 # ABACUS Technology Query UI
 
-This repository contains a Next.js chat interface and a Python backend for the ABACUS assistant. Use it to explore the Ameritas technology landscape through a conversational UI.
+This project provides an end‑to‑end chat experience built with a Next.js
+frontend and a FastAPI backend.  It is aimed at developers who need to explore
+the Ameritas technology catalog via a conversational assistant.  The backend
+coordinates calls to AWS Bedrock, the ABACUS API and a local SQLite store while
+the frontend renders a responsive UI.
 
 ## Project structure
 
 - `packages/frontend` – React application powered by Next.js
 - `packages/backend` – FastAPI service that handles `/ask` requests
 
+## Architecture
+
+```mermaid
+flowchart TD
+    browser["User Browser"] -->|HTTP| frontend["Next.js UI"]
+    frontend -->|POST /ask| backend["FastAPI service"]
+    backend --> orchestrator["Orchestrator"]
+    orchestrator --> bedrock["AWS Bedrock"]
+    orchestrator --> abacus["ABACUS API"]
+    orchestrator --> memory["SQLite Memory"]
+```
+
 ## Getting started
+
+For a step‑by‑step installation guide see [INSTALL.md](INSTALL.md).
 
 ### Frontend
 


### PR DESCRIPTION
## Summary
- document architecture with a Mermaid diagram
- point developers to a new INSTALL.md guide
- add a dedicated installation document

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687a79f1ccdc832fb33304fa3e28a839