### PR TITLE
Add proxy support and bypass for Bedrock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ ABACUS_TIMEOUT=15
 # SSL verification for external services
 VERIFY_SSL=true
 
+# Optional: proxy configuration used by both services
+# Uncomment and set your corporate proxy URLs if needed
+# HTTP_PROXY=http://proxy.example.com:8080
+# HTTPS_PROXY=http://proxy.example.com:8080
+# NO_PROXY=localhost,127.0.0.1
+
 # Application settings
 APP_NAME=AskABACUS
 APP_LOGO=/images/ameritas-logo.png

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,11 @@ This document describes how to set up the frontend and backend for local develop
 - **Python 3.10+** for the FastAPI backend
 - Optional: Docker and Docker Compose for containerized runs
 
+If your organization routes traffic through a proxy, set `HTTP_PROXY`,
+`HTTPS_PROXY`, and optionally `NO_PROXY` in your environment or `.env` file
+before running the setup commands. The backend bypasses these variables when
+contacting Bedrock so calls to AWS are direct.
+
 ## Frontend setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ Copy `.env.example` to `.env` and provide values for the following settings:
 - `NEXT_PUBLIC_API_URL` – URL of the backend for the frontend to call
 - Optional: `APP_NAME`, `APP_LOGO`, `ALLOWED_ORIGINS`, and `LONG_TERM_PATH`
 
+### Proxy configuration
+
+If your environment requires an HTTP proxy, set the standard `HTTP_PROXY`,
+`HTTPS_PROXY`, and `NO_PROXY` variables in your `.env` file. Docker Compose and
+the local deployment script will pass these values to both the frontend and
+backend services. Bedrock requests ignore these variables so traffic to AWS is
+direct.
+
 ## Features
 
 - Suggested prompts loaded from `public/prompts.json`

--- a/deploy_local.bat
+++ b/deploy_local.bat
@@ -2,6 +2,11 @@
 rem Build and run the frontend and backend locally without Docker.
 rem Usage: deploy_local.bat
 
+rem Load optional environment variables (including proxy settings)
+if exist ..\.env (
+  for /f "usebackq tokens=1,* delims==" %%i in (..\.env) do set "%%i=%%j"
+)
+
 pushd %~dp0\packages\frontend
 pnpm install
 pnpm build

--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Load optional environment variables (including proxy settings)
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source .env
+    set +a
+fi
+
 pushd packages/frontend
 pnpm install
 pnpm build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,20 @@ services:
       dockerfile: Dockerfile.frontend
     ports:
       - "3000:3000"
+    environment:
+      - HTTP_PROXY
+      - HTTPS_PROXY
+      - NO_PROXY
   backend:
     build:
       context: .
       dockerfile: Dockerfile.backend
     env_file:
       - .env
+    environment:
+      - HTTP_PROXY
+      - HTTPS_PROXY
+      - NO_PROXY
     ports:
       - "8000:8000"
     volumes:

--- a/packages/backend/bedrock_adapter.py
+++ b/packages/backend/bedrock_adapter.py
@@ -57,6 +57,9 @@ class BedrockAdapter:
                 json=payload,
                 timeout=self.timeout,
                 verify=self.verify_ssl,
+                # Explicitly disable proxies so Bedrock calls bypass any
+                # HTTP_PROXY/HTTPS_PROXY environment settings.
+                proxies={"http": None, "https": None},
             )
             response.raise_for_status()
             return response.json()

--- a/tests/test_bedrock_adapter.py
+++ b/tests/test_bedrock_adapter.py
@@ -28,3 +28,27 @@ def test_create_returns_chat_format(monkeypatch):
     assert captured["payload"]["model"] == "model"
     assert captured["payload"]["messages"] == messages
     assert resp["choices"][0]["message"]["content"] == "ok"
+
+
+def test_request_disables_proxies(monkeypatch):
+    adapter = bedrock_adapter.BedrockAdapter(
+        api_base="http://bedrock", api_key="key", model_id="model"
+    )
+
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None, verify=None, proxies=None):
+        captured["proxies"] = proxies
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {}
+
+        return Resp()
+
+    monkeypatch.setattr(bedrock_adapter.requests, "post", fake_post)
+    adapter._request({})
+    assert captured["proxies"] == {"http": None, "https": None}


### PR DESCRIPTION
## Summary
- document optional HTTP proxy variables
- pass proxy env vars through docker-compose and local scripts
- skip proxy for Bedrock requests
- load `.env` in local deployment scripts
- describe proxy usage in docs
- update tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687a7afb8184832fa641ad8172bbad92