### PR TITLE
Fix Tailwind config path in postcss

### DIFF
--- a/packages/frontend/postcss.config.mjs
+++ b/packages/frontend/postcss.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: {
+      config: "../../tailwind.config.ts",
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- fix PostCSS configuration so Tailwind loads the monorepo config

## Testing
- `pnpm dev` *(fails: next not found)*
- `pnpm install` *(fails: 403 from registry)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx, requests, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_687ad40206d4832f8344749fea748299