### PR TITLE
Add autoprefixer plugin

### DIFF
--- a/packages/frontend/postcss.config.mjs
+++ b/packages/frontend/postcss.config.mjs
@@ -4,6 +4,7 @@ const config = {
     tailwindcss: {
       config: "../../tailwind.config.ts",
     },
+    autoprefixer: {},
   },
 };
 


### PR DESCRIPTION
## Summary
- include `autoprefixer` in PostCSS config

## Testing
- `pnpm install` *(fails: No authorization header)*
- `pnpm build` *(fails: next not found)*
- `PYTHONPATH=. pytest -q ../../tests` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687ad5e83350832f93c3a7acc1879a2e