### PR TITLE
Update frontend setup docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,9 +15,12 @@ contacting Bedrock so calls to AWS are direct.
 
 ## Frontend setup
 
+Ensure **Node.js 18+** is available. Change into the frontend directory before
+installing dependencies:
+
 ```bash
 cd packages/frontend
-pnpm install
+pnpm install    # add --loglevel debug for detailed output
 pnpm dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ For a step‑by‑step installation guide see [INSTALL.md](INSTALL.md).
 
 ### Frontend
 
+Ensure you have **Node.js 18+** installed. Change into the frontend directory
+before installing dependencies:
+
 ```bash
 cd packages/frontend
-pnpm install
+pnpm install      # use `pnpm install --loglevel debug` for verbose logs
 pnpm dev
 ```
 


### PR DESCRIPTION
## Summary
- clarify that Node 18+ is required
- instruct to change into `packages/frontend` before installing
- show how to get verbose logs with `--loglevel debug`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687ae05029a0832fbf5321aa4341cba8