### PR TITLE
Add autoprefixer and styled dependencies

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -59,13 +59,15 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "@emotion/styled": "^11.14.1"
   },
   "devDependencies": {
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "postcss": "^8.5",
+    "autoprefixer": "^10.4.17",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary
- add `@emotion/styled` to dependencies
- add `autoprefixer` to devDependencies

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/autoprefixer Forbidden)*
- `pnpm build` *(fails: next not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687af0cd62d8832f903206c7a5a68ce1